### PR TITLE
Move nodemon to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "express": "^4.17.3",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.2.9",
-    "nodemon": "^2.0.15",
     "validator": "^13.7.0"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.15"
   }
 }


### PR DESCRIPTION
As `nodemon` is only used when developing the project, it should be registered as dev dependency. When installing dev dependencies, use the `-D` argument, like in `npm install -D nodemon`.